### PR TITLE
Reversed the event timelime

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,86 +835,77 @@
 
             // dataRoot : '/'
             var myMappedObject = [
-                  {
-                      "isSelected": "true",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2018",
-                      "taskShortDate": "2018",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>10th Year of PyCon India</h3><p class=''>22nd - 26th August 2018<br>Bengaluru International Exhibition Centre, Bengaluru<br> </p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2017",
-                      "taskShortDate": "2017",
-                     "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>9th Year of PyCon India</h3><p class=''>2nd, 3rd, 4th and 5th November 2017<br>Shaheed Sukhdev College Of Business Studies ,New Delhi  <br><a href='https://in.pycon.org/2017/'>https://in.pycon.org/2017/</a></p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2016",
-                      "taskShortDate": "2016",
-                     "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>8th Year of PyCon India</h3><p class=''>23rd, 24th and 25th September 2016<br>JNU Convention Center, New Delhi<br><a href='https://in.pycon.org/2016/'>https://in.pycon.org/2016/</a> </p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2015",
-                      "taskShortDate": "2015",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>7th Year of PyCon India</h3><p class=''>3rd, 4th and 5th October 2015<br>NIMHANS Convention Centre, Bangalore<br><a href='https://in.pycon.org/2015/'>https://in.pycon.org/2015/</a></p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2014",
-                      "taskShortDate": "2014",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>6th Year of PyCon India</h3><p class=''>26th, 27th and 28th September 2014<br>NIMHANS Convention Centre, Bangalore<br><a href='https://in.pycon.org/2014/'>https://in.pycon.org/2014/</a></p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2013",
-                      "taskShortDate": "2013",
-                     "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>4th Year of PyCon India</h3><p class=''>30th, 31st August and 1th September 2013<br>NIMHANS Convention Centre, Bangalore<br><a href='https://in.pycon.org/2013/'>https://in.pycon.org/2013/</a> </p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2012",
-                      "taskShortDate": "2012",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>4th Year of PyCon India</h3><p class=''> 28th, 29th and 30th September 2012 <br>DHARMARAM VIDYA KSHETRAM ,Christ University Campus, Bangalore<br><a href='https://in.pycon.org/2012/'>https://in.pycon.org/2012/</a></p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2011",
-                      "taskShortDate": "2011",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>3rd Year of PyCon India</h3><p class=''>16th, 17th and 18th September 2011.<br> Symbiosis Vishwabhavan, S.B. Road, Pune<br><a href='https://in.pycon.org/2011/'>https://in.pycon.org/2011/</a> </p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2010",
-                      "taskShortDate": "2010",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>2nd Year of PyCon India</h3><p class=''>25th and 26th, September 2010<br>M S Ramaiah Institute of Technology, Bangalore <br> <a href='https://in.pycon.org/2010/'>https://in.pycon.org/2010/</a></p></div></div>"
-                  },
-                  {
-                      "isSelected": "",
-                      "taskTitle": "",
-                      "taskSubTitle": "",
-                      "assignDate": "25/08/2009",
-                      "taskShortDate": "2009",
-                      "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>1st Year of PyCon India</h3><p class=''>26th and 27th September, 2009 <br>  Indian Institute of Science, Bangalore<br><a href='https://in.pycon.org/2009/'>https://in.pycon.org/2009/</a></p></div></div>"
-                  }
+              {
+                  "isSelected": "",
+                  "taskTitle": "",
+                  "taskSubTitle": "",
+                  "assignDate": "25/08/2009",
+                  "taskShortDate": "2009",
+                  "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>1st Year of PyCon India</h3><p class=''>26th and 27th September, 2009 <br>  Indian Institute of Science, Bangalore<br><a href='https://in.pycon.org/2009/'>https://in.pycon.org/2009/</a></p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2010",
+                "taskShortDate": "2010",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>2nd Year of PyCon India</h3><p class=''>25th and 26th, September 2010<br>M S Ramaiah Institute of Technology, Bangalore <br> <a href='https://in.pycon.org/2010/'>https://in.pycon.org/2010/</a></p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2011",
+                "taskShortDate": "2011",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>3rd Year of PyCon India</h3><p class=''>16th, 17th and 18th September 2011.<br> Symbiosis Vishwabhavan, S.B. Road, Pune<br><a href='https://in.pycon.org/2011/'>https://in.pycon.org/2011/</a> </p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2012",
+                "taskShortDate": "2012",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>4th Year of PyCon India</h3><p class=''> 28th, 29th and 30th September 2012 <br>DHARMARAM VIDYA KSHETRAM ,Christ University Campus, Bangalore<br><a href='https://in.pycon.org/2012/'>https://in.pycon.org/2012/</a></p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2013",
+                "taskShortDate": "2013",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>4th Year of PyCon India</h3><p class=''>30th, 31st August and 1th September 2013<br>NIMHANS Convention Centre, Bangalore<br><a href='https://in.pycon.org/2013/'>https://in.pycon.org/2013/</a> </p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2014",
+                "taskShortDate": "2014",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>6th Year of PyCon India</h3><p class=''>26th, 27th and 28th September 2014<br>NIMHANS Convention Centre, Bangalore<br><a href='https://in.pycon.org/2014/'>https://in.pycon.org/2014/</a></p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2015",
+                "taskShortDate": "2015",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>7th Year of PyCon India</h3><p class=''>3rd, 4th and 5th October 2015<br>NIMHANS Convention Centre, Bangalore<br><a href='https://in.pycon.org/2015/'>https://in.pycon.org/2015/</a></p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2016",
+                "taskShortDate": "2016",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>8th Year of PyCon India</h3><p class=''>23rd, 24th and 25th September 2016<br>JNU Convention Center, New Delhi<br><a href='https://in.pycon.org/2016/'>https://in.pycon.org/2016/</a> </p></div></div>"
+              }, {
+                "isSelected": "",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2017",
+                "taskShortDate": "2017",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>9th Year of PyCon India</h3><p class=''>2nd, 3rd, 4th and 5th November 2017<br>Shaheed Sukhdev College Of Business Studies ,New Delhi  <br><a href='https://in.pycon.org/2017/'>https://in.pycon.org/2017/</a></p></div></div>"
+              }, {
+                "isSelected": "true",
+                "taskTitle": "",
+                "taskSubTitle": "",
+                "assignDate": "25/08/2018",
+                "taskShortDate": "2018",
+                "taskDetails": "<div class='pycon-card row text-left'><div class='col-md-5 no-padding'><img src='img/card-image.png' alt='image' style='width:100%;border-radius: 15px 0px 0px 15px;'></div><div class='col-md-7'><img src='img/ran1.jpg' alt='img' class='pycon-ran'><h3>10th Year of PyCon India</h3><p class=''>22nd - 26th August 2018<br>Bengaluru International Exhibition Centre, Bengaluru<br> </p></div></div>"
+              }
 
             ];
 


### PR DESCRIPTION
This is how it looks after the changes I made - 
![selection_183](https://user-images.githubusercontent.com/357253/34452084-a0e37662-ed5d-11e7-9de0-159e0b7beeb9.jpg)

This is how it should look like because we want people to follow the journey of PyCon India as it happened. Each box contains the dates, venue location and the website url. Keeping 2018 on focus serves absolutely no purpose because those details are already right there on the section above. Plus, we have no picture of 2018 event yet. Anyone who opens the website will see a stock image as 2018 is in focus.

If I were someone who wants to follow the timeline of PyCon India, I'd want to start from the very beginning. Let me know your comments.

PS: We're showing photo of Vidhana Soudha even for last 2 PyCon that happened in Delhi. 