### PR TITLE
Added href for webchirpy's logo (footer)

### DIFF
--- a/convince-my-boss.html
+++ b/convince-my-boss.html
@@ -162,7 +162,7 @@
                     </ul>
                 </div>
                 <div class="col-md-4">
-                    <img src="img/wc.png" alt="image">
+                    <img href="http://webchirpy.com" src="img/wc.png" alt="image">
                 </div>
             </div>
         </div>

--- a/convince-my-boss.html
+++ b/convince-my-boss.html
@@ -162,7 +162,7 @@
                     </ul>
                 </div>
                 <div class="col-md-4">
-                    <img href="http://webchirpy.com" src="img/wc.png" alt="image">
+                    <a href="http://webchirpy.com" target="_blank"> <img src="img/wc.png" alt="image" > </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Shouldn't be the footer must be consistent throughout the website. there was no redirection to webchirpy's website on convince-my-boss page, but it was on the homepage. If it was intended please let me know.