### PR TITLE
Add explicit content type and charset

### DIFF
--- a/convince-my-boss.html
+++ b/convince-my-boss.html
@@ -3,7 +3,7 @@
 
   <!-- canonical URL -->
   <link rel="canonical" href="https://in.pycon.org/2018/faq.html">
-
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <!-- Bootstrap Core CSS -->
   <link href="custom/css/bootstrap.min.css" rel="stylesheet" type="text/css">
 


### PR DESCRIPTION
On `Convince My Boss` page, a few unicode characters were being rendered wrongly due to missing explicit declaration of charset. This fixes it.

Signed-off-by: Sanket Saurav <sanketsaurav@gmail.com>